### PR TITLE
feat: Monster hit

### DIFF
--- a/Assets/Prefabs/Alcohol.prefab
+++ b/Assets/Prefabs/Alcohol.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6823260596287068354}
   m_Layer: 0
   m_Name: Alcohol
-  m_TagString: Ranged Weapon
+  m_TagString: Ranged Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Cigarette.prefab
+++ b/Assets/Prefabs/Cigarette.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 5030732104487839430}
   m_Layer: 0
   m_Name: Cigarette
-  m_TagString: Ranged Weapon
+  m_TagString: Ranged Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Coffee.prefab
+++ b/Assets/Prefabs/Coffee.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 9016068850861083609}
   m_Layer: 0
   m_Name: Coffee
-  m_TagString: Ranged Weapon
+  m_TagString: Ranged Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Knife.prefab
+++ b/Assets/Prefabs/Knife.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 7039786901740709865}
   m_Layer: 0
   m_Name: Knife
-  m_TagString: Weapon
+  m_TagString: Melee Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -292,6 +292,7 @@ GameObject:
   - component: {fileID: 180152027}
   - component: {fileID: 180152029}
   - component: {fileID: 180152028}
+  - component: {fileID: 180152030}
   m_Layer: 0
   m_Name: Radar
   m_TagString: Untagged
@@ -362,6 +363,33 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 10
+--- !u!50 &180152030
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180152026}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1 &186590576
 GameObject:
   m_ObjectHideFlags: 0
@@ -821,6 +849,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
+      propertyPath: m_TagString
+      value: Ranged Weapon(Monster)
+      objectReference: {fileID: 0}
     - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
       propertyPath: m_LocalPosition.x
       value: -4.739
@@ -968,7 +1000,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
       propertyPath: m_TagString
-      value: Melee Weapon
+      value: Melee Weapon(Monster)
       objectReference: {fileID: 0}
     - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1223,6 +1255,10 @@ PrefabInstance:
     - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
+      propertyPath: m_TagString
+      value: Ranged Weapon(Monster)
       objectReference: {fileID: 0}
     - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1538,6 +1574,7 @@ GameObject:
   - component: {fileID: 862663888}
   - component: {fileID: 862663887}
   - component: {fileID: 862663886}
+  - component: {fileID: 862663889}
   m_Layer: 0
   m_Name: Radar
   m_TagString: Untagged
@@ -1608,6 +1645,33 @@ Transform:
   m_Children: []
   m_Father: {fileID: 834206347}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &862663889
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 862663885}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!4 &1080582506 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
@@ -1789,7 +1853,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
       propertyPath: m_TagString
-      value: Melee Weapon
+      value: Melee Weapon(Monster)
       objectReference: {fileID: 0}
     - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2420,6 +2484,7 @@ GameObject:
   - component: {fileID: 1865216627}
   - component: {fileID: 1865216628}
   - component: {fileID: 1865216629}
+  - component: {fileID: 1865216630}
   m_Layer: 0
   m_Name: Attack Range
   m_TagString: Untagged
@@ -2490,6 +2555,33 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isDetected: 0
+--- !u!50 &1865216630
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865216626}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1 &1919572951 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
@@ -2595,6 +2687,7 @@ GameObject:
   - component: {fileID: 2111500283}
   - component: {fileID: 2111500282}
   - component: {fileID: 2111500281}
+  - component: {fileID: 2111500284}
   m_Layer: 0
   m_Name: Attack Range
   m_TagString: Untagged
@@ -2665,6 +2758,33 @@ Transform:
   m_Children: []
   m_Father: {fileID: 834206347}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &2111500284
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2111500280}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1 &2126162543
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -643,9 +643,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1129296498}
-  - {fileID: 1087119442}
-  - {fileID: 1436446904}
+  - {fileID: 1708252169}
   - {fileID: 1720518689}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -691,6 +689,7 @@ MonoBehaviour:
   angle: {fileID: 1720518688}
   moveSpeed: 10
   weaponSpeed: 10
+  attackCoolDown: 0.5
   weaponPrefabs:
   - {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
   - {fileID: 1854303780617584345, guid: 564dd942ec7652843a4c37995893d82e, type: 3}
@@ -698,7 +697,7 @@ MonoBehaviour:
   - {fileID: 1717584867156859975, guid: 5a419f3641e0f254fb84a077993a421e, type: 3}
   weapons: []
   weaponSpawnPos: {fileID: 1552663874}
-  attackCoolDown: 0.5
+  isMelee: 1
 --- !u!70 &418332290
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -1471,68 +1470,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!1 &1087119441
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1087119442}
-  m_Layer: 0
-  m_Name: Coffee Pool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1087119442
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1087119441}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 418332286}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1129296497
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1129296498}
-  m_Layer: 0
-  m_Name: Cigarette Pool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1129296498
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1129296497}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 418332286}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1152133836
 GameObject:
   m_ObjectHideFlags: 0
@@ -1723,37 +1660,6 @@ Transform:
   - {fileID: 1682655842}
   - {fileID: 558399168}
   m_Father: {fileID: 1683692133}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1436446903
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1436446904}
-  m_Layer: 0
-  m_Name: Alcohol Pool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1436446904
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1436446903}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 418332286}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1552663874
 GameObject:
@@ -2098,6 +2004,37 @@ MonoBehaviour:
   attackCoolDown: 0.5
   spawnPoint: {x: 15, y: 0}
   isMelee: 1
+--- !u!1 &1708252168
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1708252169}
+  m_Layer: 0
+  m_Name: Weapons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1708252169
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1708252168}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 418332286}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1720518688
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -474,16 +474,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 2126162544}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &217856549 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-  m_PrefabInstance: {fileID: 528786975}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &217856550 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-  m_PrefabInstance: {fileID: 528786975}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &232533811
 GameObject:
   m_ObjectHideFlags: 0
@@ -653,6 +643,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1129296498}
+  - {fileID: 1087119442}
+  - {fileID: 1436446904}
   - {fileID: 1720518689}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -833,71 +826,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &528786975
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2126162544}
-    m_Modifications:
-    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_Name
-      value: Coffee
-      objectReference: {fileID: 0}
-    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_TagString
-      value: Ranged Weapon(Monster)
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.739
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.3299
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
 --- !u!1 &558399166
 GameObject:
   m_ObjectHideFlags: 0
@@ -982,71 +910,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1402499699}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &632947552
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1402499699}
-    m_Modifications:
-    - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_Name
-      value: Knife
-      objectReference: {fileID: 0}
-    - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_TagString
-      value: Melee Weapon(Monster)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.9630939
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 5.9316263
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0000000786805
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.00000004371139
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
 --- !u!1 &634515707
 GameObject:
   m_ObjectHideFlags: 0
@@ -1240,71 +1103,6 @@ Transform:
   - {fileID: 2173534}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &690063029
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1402499699}
-    m_Modifications:
-    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_Name
-      value: Coffee
-      objectReference: {fileID: 0}
-    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_TagString
-      value: Ranged Weapon(Monster)
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.739
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.3299
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
 --- !u!1 &744393915
 GameObject:
   m_ObjectHideFlags: 0
@@ -1486,7 +1284,8 @@ MonoBehaviour:
   radarObject: {fileID: 862663885}
   attackRangeObject: {fileID: 2111500280}
   angle: {fileID: 2126162543}
-  weapon: {fileID: 217856549}
+  weaponPrefab: {fileID: 1426898323791162227, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
+  weapon: {fileID: 0}
   weaponSpawnPos: {fileID: 186590576}
   moveSpeed: 5
   weaponSpeed: 10
@@ -1672,11 +1471,68 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!4 &1080582506 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-  m_PrefabInstance: {fileID: 1211134355}
+--- !u!1 &1087119441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1087119442}
+  m_Layer: 0
+  m_Name: Coffee Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1087119442
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087119441}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 418332286}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1129296497
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1129296498}
+  m_Layer: 0
+  m_Name: Cigarette Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1129296498
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1129296497}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 418332286}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1152133836
 GameObject:
   m_ObjectHideFlags: 0
@@ -1835,71 +1691,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1001 &1211134355
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2126162544}
-    m_Modifications:
-    - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_Name
-      value: Knife
-      objectReference: {fileID: 0}
-    - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_TagString
-      value: Melee Weapon(Monster)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.9630939
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 5.9316263
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0000000786805
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.00000004371139
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
 --- !u!1 &1402499698
 GameObject:
   m_ObjectHideFlags: 0
@@ -1930,10 +1721,39 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1682655842}
-  - {fileID: 1770989243}
-  - {fileID: 1919572952}
   - {fileID: 558399168}
   m_Father: {fileID: 1683692133}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1436446903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1436446904}
+  m_Layer: 0
+  m_Name: Alcohol Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1436446904
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1436446903}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 418332286}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1552663874
 GameObject:
@@ -2270,7 +2090,8 @@ MonoBehaviour:
   radarObject: {fileID: 180152026}
   attackRangeObject: {fileID: 1865216626}
   angle: {fileID: 1402499698}
-  weapon: {fileID: 1919572951}
+  weaponPrefab: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
+  weapon: {fileID: 0}
   weaponSpawnPos: {fileID: 558399166}
   moveSpeed: 5
   weaponSpeed: 10
@@ -2468,11 +2289,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 7
---- !u!4 &1770989243 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4110655315832862341, guid: 5d03364fda2953a4f871698c079ed618, type: 3}
-  m_PrefabInstance: {fileID: 690063029}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1865216626
 GameObject:
   m_ObjectHideFlags: 0
@@ -2582,16 +2398,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!1 &1919572951 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-  m_PrefabInstance: {fileID: 632947552}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1919572952 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7456163345470235896, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
-  m_PrefabInstance: {fileID: 632947552}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2053538597
 GameObject:
   m_ObjectHideFlags: 0
@@ -2815,8 +2621,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2053538598}
-  - {fileID: 217856550}
-  - {fileID: 1080582506}
   - {fileID: 186590578}
   m_Father: {fileID: 834206347}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -89,5 +89,16 @@ public class Monster : MonoBehaviour
         }
         angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, 0);
     }
-    
+    private void OnTriggerEnter2D(Collider2D col)
+    {
+        if (col.tag == "Ranged Weapon(Player)")
+        {
+            Debug.Log("몬스터 피격(원거리)");
+            Destroy(col.gameObject);
+        }
+        else if (col.tag == "Melee Weapon(Player)")
+        {
+            Debug.Log("몬스터 피격(근거리)");
+        }
+    }
 }

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -7,6 +7,7 @@ public class Monster : MonoBehaviour
     public GameObject radarObject;
     public GameObject attackRangeObject;
     public GameObject angle;
+    public GameObject weaponPrefab;
     public GameObject weapon;
     public GameObject weaponSpawnPos;
     public float moveSpeed = 5f;
@@ -23,6 +24,15 @@ public class Monster : MonoBehaviour
         radar = radarObject.GetComponent<Radar>();
         attackRange = attackRangeObject.GetComponent<Radar>();
         player = GameObject.FindGameObjectWithTag("Player");
+        weapon = Instantiate(weaponPrefab);
+        if (isMelee)
+            weapon.tag = "Melee Weapon(Monster)";
+        else
+        {
+            weapon.tag = "Ranged Weapon(Monster)";
+            weapon.GetComponent<Collider2D>().enabled = false;
+        }
+
     }
     private void Update()
     {
@@ -68,6 +78,7 @@ public class Monster : MonoBehaviour
             Vector2 shootingDir = (Vector2)player.transform.position - (Vector2)weaponSpawnPos.transform.position;
             shootingDir.Normalize();
             GameObject shootingObject = Instantiate(weapon);
+            shootingObject.GetComponent<Collider2D>().enabled = true;
             shootingObject.transform.position = weaponSpawnPos.transform.position;
             shootingObject.transform.up = shootingDir;
             shootingObject.GetComponent<Rigidbody2D>().velocity = shootingDir * weaponSpeed;
@@ -75,7 +86,6 @@ public class Monster : MonoBehaviour
     }
     private void SetWeapon()
     {
-        weapon.gameObject.SetActive(true);
         weapon.transform.position = weaponSpawnPos.transform.position;
         weapon.transform.rotation = weaponSpawnPos.transform.rotation;
     }
@@ -85,7 +95,7 @@ public class Monster : MonoBehaviour
         {
             angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, i);
             if (i == 0) Shoot();
-            yield return new WaitForSeconds(0.002f);
+            yield return new WaitForSeconds(0.001f);
         }
         angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, 0);
     }

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -25,6 +25,7 @@ public class Monster : MonoBehaviour
         attackRange = attackRangeObject.GetComponent<Radar>();
         player = GameObject.FindGameObjectWithTag("Player");
         weapon = Instantiate(weaponPrefab);
+        weapon.transform.parent = transform;
         if (isMelee)
             weapon.tag = "Melee Weapon(Monster)";
         else

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -119,14 +119,14 @@ public class Player : MonoBehaviour
     }
     private void OnTriggerEnter2D(Collider2D col)
     {
-        if(col.tag == "Ranged Weapon")
+        if(col.tag == "Ranged Weapon(Monster)")
         {
-            Debug.Log("원거리 무기");
+            Debug.Log("플레이어 피격(원거리)");
             Destroy(col.gameObject);
         }
-        else if(col.tag == "Melee Weapon")
+        else if(col.tag == "Melee Weapon(Monster)")
         {
-            Debug.Log("근거리 무기");
+            Debug.Log("플레이어 피격(근거리)");
         }
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -69,6 +69,7 @@ public class Player : MonoBehaviour
             weapons[2].gameObject.SetActive(false);
             weapons[3].gameObject.SetActive(false);
             weapon = weapons[1];
+            weapon.GetComponent<Collider2D>().enabled = false;
         }
         else if (Input.GetKeyDown(KeyCode.Alpha3))
         {
@@ -78,6 +79,7 @@ public class Player : MonoBehaviour
             weapons[1].gameObject.SetActive(false);
             weapons[3].gameObject.SetActive(false);
             weapon = weapons[2];
+            weapon.GetComponent<Collider2D>().enabled = false;
         }
         else if (Input.GetKeyDown(KeyCode.Alpha4))
         {
@@ -87,13 +89,14 @@ public class Player : MonoBehaviour
             weapons[1].gameObject.SetActive(false);
             weapons[2].gameObject.SetActive(false);
             weapon = weapons[3];
+            weapon.GetComponent<Collider2D>().enabled = false;
         }
         weapon.transform.position = weaponSpawnPos.transform.position;
         weapon.transform.rotation = weaponSpawnPos.transform.rotation;
     }
     void Attack()
     {
-        if (Input.GetMouseButtonDown(0) && Time.time > nextAttack)
+        if (Input.GetMouseButton(0) && Time.time > nextAttack)
         {
             nextAttack = Time.time + attackCoolDown;
             StartCoroutine(Swing());
@@ -102,6 +105,7 @@ public class Player : MonoBehaviour
                 Vector2 shootingDir = (Vector2)mainCamera.ScreenToWorldPoint(Input.mousePosition) - (Vector2)transform.position;
                 shootingDir.Normalize();
                 GameObject shootingObject = Instantiate(weapon);
+                shootingObject.GetComponent<Collider2D>().enabled = true;
                 shootingObject.transform.position = weaponSpawnPos.transform.position;
                 shootingObject.transform.right = shootingDir;
                 shootingObject.GetComponent<Rigidbody2D>().velocity = shootingDir * weaponSpeed;
@@ -113,7 +117,7 @@ public class Player : MonoBehaviour
         for (int i = 90; i >= -90; i--)
         {
             angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, i);
-            yield return new WaitForSeconds(0.002f);
+            yield return new WaitForSeconds(0.001f);
         }
         angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, 0);
     }
@@ -123,6 +127,7 @@ public class Player : MonoBehaviour
         {
             Debug.Log("플레이어 피격(원거리)");
             Destroy(col.gameObject);
+
         }
         else if(col.tag == "Melee Weapon(Monster)")
         {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -4,9 +4,11 @@
 TagManager:
   serializedVersion: 2
   tags:
-  - Melee Weapon
-  - Ranged Weapon
   - Weapon
+  - Melee Weapon(Player)
+  - Ranged Weapon(Player)
+  - Melee Weapon(Monster)
+  - Ranged Weapon(Monster)
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
몬스터 피격:
- 원거리: 충돌 오브젝트 삭제 후 피격 로그 출력
- 근거리: 피격 로그 출력

버그 수정:
원거리 무기가 상대 오브젝트와 충돌 시 삭제 되도록 설계해서 두 오브젝트가 가까이 붙었을 때 손에 들고 있는 오브젝트까지 삭제시키는 버그가 발생
- 손에 들고 있는 무기의 콜라이더를 비활성화 시키고 발사되는 투사체 오브젝트만 콜라이더를 활성화하는 방법으로 해결