### PR TITLE
feat: Change Item damage implementation

### DIFF
--- a/Assets/Scripts/Item/Item.cs
+++ b/Assets/Scripts/Item/Item.cs
@@ -42,6 +42,37 @@ namespace Item
             Nicotine = 0;
             Damage = damage;
         }
+        public static DamageHolder operator +(DamageHolder a)
+            => a;
+        public static DamageHolder operator -(DamageHolder a)
+            => new (-a.Caffeine, -a.Alcohol, -a.Nicotine, -a.Damage);
+        
+        public static DamageHolder operator +(DamageHolder a, DamageHolder b)
+        => new (
+            a.Caffeine + b.Caffeine,
+            a.Alcohol + b.Alcohol,
+            a.Nicotine + b.Nicotine,
+            a.Damage + b.Damage
+        );
+        
+        public static DamageHolder operator -(DamageHolder a, DamageHolder b)
+            => a + (-b);
+        
+        public static DamageHolder operator *(DamageHolder a, float ratio) 
+            => new (
+                a.Caffeine * ratio,
+                a.Alcohol * ratio,
+                a.Nicotine * ratio,
+                a.Damage * ratio
+            );
+        
+        public static DamageHolder operator *(DamageHolder a, DamageHolder b)
+            => new (
+                a.Caffeine * b.Caffeine,
+                a.Alcohol * b.Alcohol,
+                a.Nicotine * b.Nicotine,
+                a.Damage * b.Damage
+            );
     }
 
     public enum ItemType  // 아이템 유형
@@ -74,5 +105,13 @@ namespace Item
             this.alcohol = alcohol;
             this.nicotine = nicotine;
         }
+
+        public virtual DamageHolder GetDamageHolder()
+            => new DamageHolder(
+                this.caffeine,
+                this.alcohol,
+                this.nicotine,
+                0.0f
+            );
     }
 }

--- a/Assets/Scripts/Item/Item.cs
+++ b/Assets/Scripts/Item/Item.cs
@@ -20,17 +20,27 @@ namespace Item
      * 3. 모든 스킬을 반영해 계산된 최종 스탯 객체를 m의 damage 메소드로 전달합니다.
      * 4. 몬스터 객체의 damage 메소드에서 스텟에 따른 피해를 계산합니다.
      */
-    public class ElementalStatus
+    public class DamageHolder
     {
         public readonly float Caffeine;
         public readonly float Alcohol;
         public readonly float Nicotine;
+        public readonly float Damage;
 
-        public ElementalStatus(float caffeine, float alcohol, float nicotine)
+        public DamageHolder(float caffeine, float alcohol, float nicotine, float damage)
         {
             Caffeine = caffeine;
             Alcohol = alcohol;
             Nicotine = nicotine;
+            Damage = damage;
+        }
+
+        public DamageHolder(float damage)
+        {
+            Caffeine = 0;
+            Alcohol = 0;
+            Nicotine = 0;
+            Damage = damage;
         }
     }
 
@@ -47,7 +57,9 @@ namespace Item
      */
     public class Item: MonoBehaviour
     {
-        public ElementalStatus Stat;
+        public float caffeine;
+        public float alcohol;
+        public float nicotine;
         
         public string itemName; // 
         public ItemType itemType; // 
@@ -56,14 +68,11 @@ namespace Item
         [TextArea]  // 여러 줄 가능해짐
         public string itemDesc; // 아이템의 설명
 
-        public Item(ElementalStatus s)
-        {
-            Stat = s;
-        }
-
         public Item(float caffeine, float alcohol, float nicotine)
         {
-            Stat = new ElementalStatus(caffeine, alcohol, nicotine);
+            this.caffeine = caffeine;
+            this.alcohol = alcohol;
+            this.nicotine = nicotine;
         }
     }
 }

--- a/Assets/Scripts/Item/UsableItem.cs
+++ b/Assets/Scripts/Item/UsableItem.cs
@@ -3,7 +3,7 @@
     public class UsableItem : Item
     {
 
-        public UsableItem(ElementalStatus s) : base(s)
+        public UsableItem(float caffeine, float alcohol, float nicotine) : base(caffeine, alcohol, nicotine)
         {
         }
 

--- a/Assets/Scripts/Item/Weapon.cs
+++ b/Assets/Scripts/Item/Weapon.cs
@@ -2,10 +2,10 @@
 {
     public class Weapon: Item
     {
-        public float Damage;
-        public Weapon(ElementalStatus s, float damage): base(s)
+        public float damage;
+        public Weapon(float caffeine, float alcohol, float nicotine, float damage): base(caffeine, alcohol, nicotine)
         {
-            Damage = damage;
+            damage = damage;
         }
     }
 }

--- a/Assets/Scripts/Item/Weapon.cs
+++ b/Assets/Scripts/Item/Weapon.cs
@@ -7,5 +7,13 @@
         {
             damage = damage;
         }
+
+        public override DamageHolder GetDamageHolder()
+            => new DamageHolder(
+                this.caffeine,
+                this.alcohol,
+                this.nicotine,
+                this.damage
+            );
     }
 }


### PR DESCRIPTION
기존 아이템의 ElementalStatus 객체를 제거하고, 아이템 객체 자체가 3가지 속성의 수치를 표현하도록 구현을 변경했습니다.
대신, 기존의 ElementalStatus 객체를 확장해 데미지 관련 이벤트 처리시 사용할 수 있는 Data Object인 `DamageHolder` 객체를 만들어, 해당 이벤트에서 처리되야 하는 데미지 및 3가지 속성 수치를 저장하게끔 구현했습니다.