### PR TITLE
feat: Entity Hit

### DIFF
--- a/Assets/Prefabs/Alcohol.prefab
+++ b/Assets/Prefabs/Alcohol.prefab
@@ -12,9 +12,10 @@ GameObject:
   - component: {fileID: 2357533434980876242}
   - component: {fileID: -385254601836969344}
   - component: {fileID: 6823260596287068354}
+  - component: {fileID: 775397459117901850}
   m_Layer: 0
   m_Name: Alcohol
-  m_TagString: Ranged Weapon(Player)
+  m_TagString: Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -148,3 +149,23 @@ CapsuleCollider2D:
   m_Offset: {x: 0.0019221008, y: 0}
   m_Size: {x: 0.318994, y: 0.85333335}
   m_Direction: 0
+--- !u!114 &775397459117901850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854303780617584345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed4cda96b82d4427a13c07ce47280527, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  caffeine: 0
+  alcohol: 0
+  nicotine: 0
+  itemName: 
+  itemType: 0
+  itemImage: {fileID: 0}
+  itemDesc: 
+  damage: 1

--- a/Assets/Prefabs/Cigarette.prefab
+++ b/Assets/Prefabs/Cigarette.prefab
@@ -12,9 +12,10 @@ GameObject:
   - component: {fileID: 7578932338337641736}
   - component: {fileID: -3500097506522250148}
   - component: {fileID: 5030732104487839430}
+  - component: {fileID: 3377071193291869923}
   m_Layer: 0
   m_Name: Cigarette
-  m_TagString: Ranged Weapon(Player)
+  m_TagString: Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -158,3 +159,23 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.43537456, y: 0.08923389}
   m_EdgeRadius: 0
+--- !u!114 &3377071193291869923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717584867156859975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed4cda96b82d4427a13c07ce47280527, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  caffeine: 0
+  alcohol: 0
+  nicotine: 0
+  itemName: 
+  itemType: 0
+  itemImage: {fileID: 0}
+  itemDesc: 
+  damage: 1

--- a/Assets/Prefabs/Coffee.prefab
+++ b/Assets/Prefabs/Coffee.prefab
@@ -12,9 +12,10 @@ GameObject:
   - component: {fileID: 9159825621501671420}
   - component: {fileID: -1160668164774514604}
   - component: {fileID: 9016068850861083609}
+  - component: {fileID: 7594881839001062966}
   m_Layer: 0
   m_Name: Coffee
-  m_TagString: Ranged Weapon(Player)
+  m_TagString: Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -164,3 +165,23 @@ EdgeCollider2D:
   m_AdjacentEndPoint: {x: 0, y: 0}
   m_UseAdjacentStartPoint: 0
   m_UseAdjacentEndPoint: 0
+--- !u!114 &7594881839001062966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1426898323791162227}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed4cda96b82d4427a13c07ce47280527, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  caffeine: 10
+  alcohol: 0
+  nicotine: 0
+  itemName: 
+  itemType: 0
+  itemImage: {fileID: 0}
+  itemDesc: 
+  damage: 1

--- a/Assets/Prefabs/Knife.prefab
+++ b/Assets/Prefabs/Knife.prefab
@@ -12,9 +12,10 @@ GameObject:
   - component: {fileID: 388198385748816934}
   - component: {fileID: -3079251468905652356}
   - component: {fileID: 7039786901740709865}
+  - component: {fileID: 5967434786978410537}
   m_Layer: 0
   m_Name: Knife
-  m_TagString: Melee Weapon(Player)
+  m_TagString: Weapon(Player)
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -169,3 +170,23 @@ EdgeCollider2D:
   m_AdjacentEndPoint: {x: 0, y: 0}
   m_UseAdjacentStartPoint: 0
   m_UseAdjacentEndPoint: 0
+--- !u!114 &5967434786978410537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 593603576000265972}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed4cda96b82d4427a13c07ce47280527, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  caffeine: 0
+  alcohol: 0
+  nicotine: 0
+  itemName: 
+  itemType: 0
+  itemImage: {fileID: 0}
+  itemDesc: 
+  damage: 1

--- a/Assets/Scenes/EntityScene.unity
+++ b/Assets/Scenes/EntityScene.unity
@@ -2018,6 +2018,8 @@ MonoBehaviour:
   alcohol: 0
   caffeine: 0
   nicotine: 0
+  isInvincible: 0
+  invincibleTime: 2
   angle: {fileID: 1720518688}
   weaponPrefabs:
   - {fileID: 593603576000265972, guid: e8a25c6ab6914cb4dab91e4d21255169, type: 3}
@@ -4979,6 +4981,8 @@ MonoBehaviour:
   alcohol: 0
   caffeine: 0
   nicotine: 0
+  isInvincible: 0
+  invincibleTime: 2
   radarObject: {fileID: 862663885}
   attackRangeObject: {fileID: 2111500280}
   angle: {fileID: 2126162543}
@@ -9982,6 +9986,8 @@ MonoBehaviour:
   alcohol: 0
   caffeine: 0
   nicotine: 0
+  isInvincible: 0
+  invincibleTime: 2
   radarObject: {fileID: 180152026}
   attackRangeObject: {fileID: 1865216626}
   angle: {fileID: 1402499698}
@@ -13161,7 +13167,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 10
+  m_Radius: 1.5
 --- !u!4 &2111500283
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Entity/EntityStatus.cs
+++ b/Assets/Scripts/Entity/EntityStatus.cs
@@ -10,6 +10,7 @@ public class EntityStatus : MonoBehaviour
     public float alcohol;
     public float caffeine;
     public float nicotine;
+    public bool isInvincible = false;
     public EntityStatus(float hp, float moveSpeed, float attackSpeed, float alcohol, float caffeine, float nicotine)
     {
         this.hp = hp;
@@ -18,5 +19,38 @@ public class EntityStatus : MonoBehaviour
         this.alcohol = alcohol;
         this.caffeine = caffeine;
         this.nicotine = nicotine;
+    }
+    protected void EntityHit(Item.DamageHolder currentDamageHolder)
+    {
+        alcohol += currentDamageHolder.Alcohol;
+        caffeine += currentDamageHolder.Caffeine;
+        nicotine += currentDamageHolder.Nicotine;
+        hp -= currentDamageHolder.Damage;
+    }
+    protected IEnumerator Swing(GameObject angle)
+    {
+        for (int i = 90; i >= -90; i--)
+        {
+            angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, i);
+            yield return new WaitForSeconds(0.001f);
+        }
+        angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, 0);
+
+    }
+    protected IEnumerator InvincibleMode(float time)
+    {
+        Color originalColor = gameObject.GetComponent<SpriteRenderer>().color;
+        isInvincible = true;
+        gameObject.GetComponent<SpriteRenderer>().color = new Color(0, 0, 0, 1);
+        yield return new WaitForSeconds(time);
+        gameObject.GetComponent<SpriteRenderer>().color = originalColor;
+        isInvincible = false;
+    }
+    protected void EntityDie()
+    {
+        if (hp <= 0)
+        {
+            Destroy(gameObject);
+        }
     }
 }

--- a/Assets/Scripts/Entity/Player.cs
+++ b/Assets/Scripts/Entity/Player.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class Player : EntityStatus
 {
     public Player(float hp, float moveSpeed, float attackSpeed, float alcohol, float caffeine, float nicotine) : base(hp, moveSpeed, attackSpeed, alcohol, caffeine, nicotine) { }
+    public float invincibleTime;
     public GameObject angle;
     public List<GameObject> weaponPrefabs;
     public List<GameObject> weapons;
@@ -37,6 +38,7 @@ public class Player : EntityStatus
             LookAt();
             WeaponSwap();
             Attack();
+            EntityDie();
         }
         //LookAt();
         //WeaponSwap();
@@ -98,31 +100,15 @@ public class Player : EntityStatus
             }
         }
         weapon = weapons[weaponNum];
-        if (weaponNum != 0)
-        {
-            weapon.GetComponent<Collider2D>().enabled = false;
-            isMelee = false;
-        }
     }
     void Attack()
     {
         if (Input.GetMouseButton(0) && Time.time > nextAttack)
         {
             nextAttack = Time.time + attackSpeed;
-            StartCoroutine(Swing());
+            StartCoroutine(Swing(angle));
         }
     }
-    private IEnumerator Swing()
-    {
-        for (int i = 90; i >= -90; i--)
-        {
-            angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, i);
-            yield return new WaitForSeconds(0.001f);
-        }
-        angle.transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, 0);
-
-    }
-
     void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.gameObject.CompareTag("CanBePickedUp"))
@@ -136,15 +122,12 @@ public class Player : EntityStatus
                 collision.gameObject.SetActive(false);
             }
         }
-        if (collision.tag == "Ranged Weapon(Monster)")
+        if (collision.tag == "Weapon(Monster)" && !isInvincible)
         {
-            Debug.Log("플레이어 피격(원거리)");
-            Destroy(collision.gameObject);
-
-        }
-        else if (collision.tag == "Melee Weapon(Monster)")
-        {
-            Debug.Log("플레이어 피격(근거리)");
+            Debug.Log("플레이어 피격");
+            Item.DamageHolder currentDamageHolder = collision.GetComponent<Item.Weapon>().GetDamageHolder();
+            EntityHit(currentDamageHolder);
+            StartCoroutine(InvincibleMode(invincibleTime));
         }
     }
 

--- a/Assets/Scripts/Item/Weapon.cs
+++ b/Assets/Scripts/Item/Weapon.cs
@@ -5,7 +5,7 @@
         public float damage;
         public Weapon(float caffeine, float alcohol, float nicotine, float damage): base(caffeine, alcohol, nicotine)
         {
-            damage = damage;
+            this.damage = damage;
         }
 
         public override DamageHolder GetDamageHolder()

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,10 +6,8 @@ TagManager:
   tags:
   - Weapon
   - CanBePickedUp
-  - Melee Weapon(Player)
-  - Ranged Weapon(Player)
-  - Melee Weapon(Monster)
-  - Ranged Weapon(Monster)
+  - Weapon(Player)
+  - Weapon(Monster)
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
플레이어, 몬스터 중복 함수 상위 클래스로 이동

엔티티 피격 함수 추가:
alcohol += currentDamageHolder.Alcohol;
caffeine += currentDamageHolder.Caffeine;
nicotine += currentDamageHolder.Nicotine;
hp -= currentDamageHolder.Damage;

무적모드 함수 추가:
설정한 시간 동안 충돌 무시 + 색 변환

무적 상태 체크하는 isInvincible 추가

엔티티 사망 함수 추가

이외:
원거리 무기 삭제로 인한 태그 변경, 태그 통합, 충돌 판정 통합, 원거리 무기 관련 코드 삭제