### PR TITLE
fix: Update Inventory System

### DIFF
--- a/Assets/Scenes/EntityScene.unity
+++ b/Assets/Scenes/EntityScene.unity
@@ -1896,7 +1896,7 @@ GameObject:
   - component: {fileID: 418332285}
   - component: {fileID: 418332288}
   - component: {fileID: 418332290}
-  - component: {fileID: 418332291}
+  - component: {fileID: 418332289}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -2012,6 +2012,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3fcf385c3d58c6b4881892ee2da9d100, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  theInventory: {fileID: 1695397564}
   hp: 10
   moveSpeed: 10
   attackSpeed: 0.5
@@ -2029,7 +2030,6 @@ MonoBehaviour:
   weapons: []
   weaponSpawnPos: {fileID: 1552663874}
   isMelee: 1
-  theInventory: {fileID: 1695397564}
 --- !u!70 &418332290
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -2065,32 +2065,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 1, y: 2}
   m_Direction: 0
---- !u!114 &418332291
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 418332284}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3fcf385c3d58c6b4881892ee2da9d100, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  theInventory: {fileID: 0}
-  hp: 0
-  moveSpeed: 0
-  attackSpeed: 0
-  alcohol: 0
-  caffeine: 0
-  nicotine: 0
-  isInvincible: 0
-  invincibleTime: 0
-  angle: {fileID: 0}
-  weaponPrefabs: []
-  weapons: []
-  weaponSpawnPos: {fileID: 0}
-  isMelee: 0
 --- !u!1001 &422142671
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5038,6 +5012,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77b38dcae5b4d7e4e89a14e4e71ab5a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  theInventory: {fileID: 0}
   hp: 1
   moveSpeed: 5
   attackSpeed: 0.5
@@ -6378,6 +6353,7 @@ MonoBehaviour:
   itemDesc: 'just knife
 
     very cheap'
+  itemValue: 0
 --- !u!114 &917105268
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9928,8 +9904,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 862343959}
   - {fileID: 1239643335}
+  - {fileID: 862343959}
   - {fileID: 735965060}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10306,6 +10282,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77b38dcae5b4d7e4e89a14e4e71ab5a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  theInventory: {fileID: 0}
   hp: 1
   moveSpeed: 5
   attackSpeed: 0.5

--- a/Assets/Scripts/Entity/EntityStatus.cs
+++ b/Assets/Scripts/Entity/EntityStatus.cs
@@ -4,9 +4,6 @@ using UnityEngine;
 
 public class EntityStatus : MonoBehaviour
 {
-    [SerializeField]
-    public Inventory theInventory;
-
     public float hp;
     public float moveSpeed;
     public float attackSpeed;

--- a/Assets/Scripts/Entity/Player.cs
+++ b/Assets/Scripts/Entity/Player.cs
@@ -11,6 +11,7 @@ public class Player : EntityStatus
     public List<GameObject> weapons;
     public GameObject weaponSpawnPos;
     public bool isMelee = true;
+    public Inventory theInventory;
     private GameObject weapon;
     private float nextAttack;
 
@@ -110,12 +111,12 @@ public class Player : EntityStatus
     {
         if (collision.gameObject.CompareTag("CanBePickedUp"))
         {
-            Item.Item hitObject = collision.gameObject.GetComponent<Consumable>().item;
+            Item.Item hitObject = collision.gameObject.GetComponent<Item.Item>();
 
             if (hitObject != null)
             {
                 //Debug.Log(hitObject.transform.GetComponent<Consumable>().item.itemName + " ȹ�� �߽��ϴ�.");
-                theInventory.AcquireItem(hitObject.transform.GetComponent<Consumable>().item);
+                theInventory.AcquireItem(hitObject);
                 collision.gameObject.SetActive(false);
             }
         }

--- a/Assets/Scripts/Inventory/DragSlot.cs
+++ b/Assets/Scripts/Inventory/DragSlot.cs
@@ -20,6 +20,7 @@ public class DragSlot : MonoBehaviour
     public void DragSetImage(Image _itemImage)
     {
         imageItem.sprite = _itemImage.sprite;
+        imageItem.color = _itemImage.color;
         SetColor(1);
     }
 

--- a/Assets/Scripts/Inventory/Slot.cs
+++ b/Assets/Scripts/Inventory/Slot.cs
@@ -45,7 +45,8 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
     {
         item = _item;
         itemCount = _count;
-        itemImage.sprite = item.itemImage; //acess item image
+        itemImage.sprite = item.GetComponent<SpriteRenderer>().sprite; //acess item image
+        itemImage.color = item.GetComponent<SpriteRenderer>().color;
 
         if (item.itemType != Item.ItemType.Equipment && item.itemType != Item.ItemType.ETC)
         {

--- a/Assets/Scripts/WorldTime.cs
+++ b/Assets/Scripts/WorldTime.cs
@@ -31,7 +31,7 @@ public class WorldTime : MonoBehaviour
     }
     private void UpdateWorldTime()
     {
-        currentTime += Time.deltaTime*60;
+        currentTime += Time.deltaTime;
         float hour = currentTime / 60f;
         float minute = currentTime % 60f;
         timeText.text = string.Format("Time {0:D2} : {1:D2}", (int)hour, (int)minute);


### PR DESCRIPTION
Consumable 스크립트가 Item을 불필요하게 중복 선언한다고 판단
Consumable 스크립트를 쓰지 않도록 변경

몬스터에겐 인벤토리가 필요 없기 때문에 the Inventory 필드도 EntityStatus.cs에서 Player.cs로 이동
인벤토리 슬롯 내 아이템 이미지를 스프라이트만 반영하는 것을 색깔(Color)도 반영하도록 변경
